### PR TITLE
add support for xml and svg files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,13 @@
     "contributes": {
         "snippets": [
             {
-                "language": ["html", "xml"],
+                "language": "html",
+                "path": "./snippets/svg.json"
+            }, {
+                "language": "xml",
+                "path": "./snippets/svg.json"
+            }, {
+                "language": "svg",
                 "path": "./snippets/svg.json"
             }
         ]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "contributes": {
         "snippets": [
             {
-                "language": "html",
+                "language": ["html", "xml"],
                 "path": "./snippets/svg.json"
             }
         ]


### PR DESCRIPTION
The svg extension svg-viewer only works with xml files at the moment. And vs code sets xml as the file type for .svg files. So it makes sense to support them with this awesome snippet extension.